### PR TITLE
chat-server: update config with Field aliases and add provider-specific settings

### DIFF
--- a/chat-server/app/core/config.py
+++ b/chat-server/app/core/config.py
@@ -1,3 +1,4 @@
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -17,33 +18,37 @@ class Settings(BaseSettings):
     LLM_GATEWAY_PROVIDER: str = ""
     EMBEDDING_GATEWAY_PROVIDER: str = ""
 
-    PORTKEY_API_KEY: str = ""
-    PORTKEY_URL: str = ""
-    PORTKEY_PROVIDER_API_KEY: str = ""
-    PORTKEY_PROVIDER_NAME: str = ""
-    PORTKEY_CONFIG_ID: str = ""
-    PORTKEY_EMBEDDING_PROVIDER_API_KEY: str = ""
-    PORTKEY_EMBEDDING_PROVIDER_NAME: str = ""
+    PORTKEY_API_KEY: str = Field(default="", alias="PORTKEY_API_KEY")
+    PORTKEY_URL: str = Field(default="", alias="PORTKEY_URL")
+    PORTKEY_PROVIDER_API_KEY: str = Field(default="", alias="PORTKEY_PROVIDER_API_KEY")
+    PORTKEY_PROVIDER_NAME: str = Field(default="", alias="PORTKEY_PROVIDER_NAME")
+    PORTKEY_CONFIG_ID: str = Field(default="", alias="PORTKEY_CONFIG_ID")
+    PORTKEY_EMBEDDING_PROVIDER_API_KEY: str = Field(
+        default="", alias="PORTKEY_EMBEDDING_PROVIDER_API_KEY"
+    )
+    PORTKEY_EMBEDDING_PROVIDER_NAME: str = Field(
+        default="", alias="PORTKEY_EMBEDDING_PROVIDER_NAME"
+    )
 
-    LITELLM_BASE_URL: str = ""
-    LITELLM_MASTER_KEY: str = ""
-    LITELLM_KEY_HEADER_NAME: str = ""
-    LITELLM_VIRTUAL_KEY: str = ""
+    LITELLM_BASE_URL: str = Field(default="", alias="LITELLM_BASE_URL")
+    LITELLM_MASTER_KEY: str = Field(default="", alias="LITELLM_MASTER_KEY")
+    LITELLM_KEY_HEADER_NAME: str = Field(default="", alias="LITELLM_KEY_HEADER_NAME")
+    LITELLM_VIRTUAL_KEY: str = Field(default="", alias="LITELLM_VIRTUAL_KEY")
 
-    CLOUDFLARE_GATEWAY_URL: str = ""
-    CLOUDFLARE_API_TOKEN: str = ""
-    CLOUDFLARE_ACCOUNT_ID: str = ""
-    CLOUDFLARE_GATEWAY_ID: str = ""
-    CLOUDFLARE_PROVIDER: str = ""
-    CLOUDFLARE_PROVIDER_API_KEY: str = ""
+    CLOUDFLARE_GATEWAY_URL: str = Field(default="", alias="CLOUDFLARE_GATEWAY_URL")
+    CLOUDFLARE_API_TOKEN: str = Field(default="", alias="CLOUDFLARE_API_TOKEN")
+    CLOUDFLARE_ACCOUNT_ID: str = Field(default="", alias="CLOUDFLARE_ACCOUNT_ID")
+    CLOUDFLARE_GATEWAY_ID: str = Field(default="", alias="CLOUDFLARE_GATEWAY_ID")
+    CLOUDFLARE_PROVIDER: str = Field(default="", alias="CLOUDFLARE_PROVIDER")
+    CLOUDFLARE_PROVIDER_API_KEY: str = Field(default="", alias="CLOUDFLARE_PROVIDER_API_KEY")
 
-    OPENAI_API_KEY: str = ""
-
-    OPENROUTER_API_KEY: str = ""
-    OPENROUTER_BASE_URL: str = ""
+    OPENROUTER_API_KEY: str = Field(default="", alias="OPENROUTER_API_KEY")
+    OPENROUTER_BASE_URL: str = Field(
+        default="https://api.openrouter.ai", alias="OPENROUTER_BASE_URL"
+    )
 
     LANGSMITH_PROMPT: bool = False
-    LANGSMITH_API_KEY: str = ""
+    LANGSMITH_API_KEY: str = Field(default="", alias="LANGSMITH_API_KEY")
 
     QDRANT_HOST: str = "host.docker.local"
     QDRANT_COLLECTION: str = "dataset_collection"
@@ -55,7 +60,7 @@ class Settings(BaseSettings):
     ADVANCED_MODEL: str = ""
     BALANCED_MODEL: str = ""
     FAST_MODEL: str = ""
-    FALLBACK_MODEL: str = ""
+    FALLBACK_MODEL: str = ""  # only used by openrouter
 
     DETERMINISTIC_TEMPERATURE: float = 0.0
     LOW_VARIATION_TEMPERATURE: float = 0.3
@@ -64,11 +69,13 @@ class Settings(BaseSettings):
 
     DEFAULT_LLM_MODEL: str = ""
     DEFAULT_EMBEDDING_MODEL: str = ""
+    DEFAULT_EMBEDDING_SIZE: int = 3072
 
     E2B_API_KEY: str = ""
     E2B_TIMEOUT: int = 120
 
-    S3_HOST: str = ""
+    INTERNAL_S3_HOST: str = ""
+    EXTERNAL_S3_HOST: str = ""
     S3_ACCESS_KEY: str = ""
     S3_SECRET_KEY: str = ""
     S3_BUCKET: str = ""
@@ -76,15 +83,32 @@ class Settings(BaseSettings):
 
     CUSTOM_EMBEDDING_BASE_URL: str = ""
     CUSTOM_EMBEDDING_API_KEY: str = ""
-    CUSTOM_EMBEDDING_MODEL: str = ""
 
     CUSTOM_LLM_BASE_URL: str = ""
     CUSTOM_LLM_API_KEY: str = ""
+    CUSTOM_PROVIDER_NAME: str = "other"
+
+    # Provider-specific API keys (without CHAT_ prefix)
+    OPENAI_API_KEY: str = Field(default="", alias="OPENAI_API_KEY")
+    GROQ_API_KEY: str = Field(default="", alias="GROQ_API_KEY")
+    TOGETHER_API_KEY: str = Field(default="", alias="TOGETHER_API_KEY")
+    PERPLEXITY_API_KEY: str = Field(default="", alias="PERPLEXITY_API_KEY")
+    FIREWORKS_API_KEY: str = Field(default="", alias="FIREWORKS_API_KEY")
+    ANTHROPIC_API_KEY: str = Field(default="", alias="ANTHROPIC_API_KEY")
+    DEEPINFRA_API_TOKEN: str = Field(default="", alias="DEEPINFRA_API_TOKEN")
+    HF_TOKEN: str = Field(default="", alias="HF_TOKEN")
 
     CHAT_HISTORY_MAX_MESSAGES: int = 20
     CHAT_HISTORY_MAX_TOKENS: int = 10000
 
-    model_config = SettingsConfigDict(env_file=".env", extra="ignore", case_sensitive=True)
+    ROW_TRUNCATION_LIMIT: int = 250
+    DATASET_TOKEN_TRUNCATION_LIMIT: int = 100000
+    COLUMN_TRUNCATION_LIMIT: int = 200
+    DISPLAY_ROWS_AFTER_TRUNCATION_LIMIT: int = 20
+
+    model_config = SettingsConfigDict(
+        env_file=".env", extra="ignore", case_sensitive=True, env_prefix="CHAT_"
+    )
 
 
 settings = Settings()

--- a/chat-server/app/services/gopie/generate_schema.py
+++ b/chat-server/app/services/gopie/generate_schema.py
@@ -1,10 +1,7 @@
 from app.core.config import settings
 from app.core.session import SingletonAiohttp
 from app.models.schema import DatasetSummary
-from app.services.gopie.sql_executor import (
-    SQL_RESPONSE_TYPE,
-    execute_sql_with_limit,
-)
+from app.services.gopie.sql_executor import SQL_RESPONSE_TYPE, execute_sql
 
 
 async def generate_summary(
@@ -16,7 +13,7 @@ async def generate_summary(
     headers = {"accept": "application/json"}
 
     sample_values_query = f"SELECT DISTINCT * FROM {dataset_name} LIMIT {limit}"
-    sample_data = await execute_sql_with_limit(query=sample_values_query)
+    sample_data = await execute_sql(query=sample_values_query)
 
     data = None
 

--- a/chat-server/app/services/qdrant/qdrant_setup.py
+++ b/chat-server/app/services/qdrant/qdrant_setup.py
@@ -2,8 +2,7 @@ from uuid import UUID, uuid5
 
 from langchain_openai import OpenAIEmbeddings
 from langchain_qdrant import QdrantVectorStore
-from qdrant_client import AsyncQdrantClient, QdrantClient
-from qdrant_client.http.models import Distance, VectorParams
+from qdrant_client import AsyncQdrantClient, QdrantClient, models
 
 from app.core.config import settings
 
@@ -29,7 +28,34 @@ class QdrantSetup:
             if not await cls._async_collection_exists(cls.async_client):
                 await cls.async_client.create_collection(
                     collection_name=settings.QDRANT_COLLECTION,
-                    vectors_config=VectorParams(size=3072, distance=Distance.COSINE),
+                    vectors_config=models.VectorParams(
+                        size=settings.DEFAULT_EMBEDDING_SIZE,
+                        distance=models.Distance.COSINE,
+                        on_disk=True,
+                    ),
+                    hnsw_config=models.HnswConfigDiff(
+                        m=16,
+                        ef_construct=100,
+                        full_scan_threshold=20,
+                        max_indexing_threads=0,
+                        on_disk=False,
+                    ),
+                    optimizers_config=models.OptimizersConfigDiff(
+                        deleted_threshold=0.2,
+                        vacuum_min_vector_number=1000,
+                        default_segment_number=0,
+                        max_segment_size=None,
+                        memmap_threshold=None,
+                        indexing_threshold=40,
+                        flush_interval_sec=5,
+                        max_optimization_threads=None,
+                    ),
+                    wal_config=models.WalConfigDiff(wal_capacity_mb=32, wal_segments_ahead=0),
+                    quantization_config=models.ScalarQuantization(
+                        scalar=models.ScalarQuantizationConfig(
+                            type=models.ScalarType.INT8, always_ram=True
+                        )
+                    ),
                 )
         return cls.async_client
 
@@ -43,7 +69,34 @@ class QdrantSetup:
             if not cls._collection_exists(cls.sync_client):
                 cls.sync_client.create_collection(
                     collection_name=settings.QDRANT_COLLECTION,
-                    vectors_config=VectorParams(size=3072, distance=Distance.COSINE),
+                    vectors_config=models.VectorParams(
+                        size=settings.DEFAULT_EMBEDDING_SIZE,
+                        distance=models.Distance.COSINE,
+                        on_disk=True,
+                    ),
+                    hnsw_config=models.HnswConfig(
+                        m=16,
+                        ef_construct=100,
+                        full_scan_threshold=20,
+                        max_indexing_threads=0,
+                        on_disk=False,
+                    ),
+                    optimizers_config=models.OptimizersConfigDiff(
+                        deleted_threshold=0.2,
+                        vacuum_min_vector_number=1000,
+                        default_segment_number=0,
+                        max_segment_size=None,
+                        memmap_threshold=None,
+                        indexing_threshold=40,
+                        flush_interval_sec=5,
+                        max_optimization_threads=None,
+                    ),
+                    wal_config=models.WalConfigDiff(wal_capacity_mb=32, wal_segments_ahead=0),
+                    quantization_config=models.ScalarQuantization(
+                        scalar=models.ScalarQuantizationConfig(
+                            type=models.ScalarType.INT8, always_ram=True
+                        )
+                    ),
                 )
         return cls.sync_client
 

--- a/chat-server/app/utils/graph_utils/result_validation.py
+++ b/chat-server/app/utils/graph_utils/result_validation.py
@@ -2,6 +2,7 @@ import json
 
 from langsmith import traceable
 
+from app.core.config import settings
 from app.core.log import custom_logger as logger
 
 
@@ -16,16 +17,20 @@ def is_result_too_large(result: list[dict]) -> tuple[bool, str]:
         If the result is acceptable or an error occurs, returns (False, "").
     """
     try:
-        if len(result) > 200:
+        if len(result) > settings.ROW_TRUNCATION_LIMIT:
             return True, f"Query returned too many records: {len(result)}"
 
         result_json = json.dumps(result)
         # ~25k tokens approximation
-        if len(result_json) > 100000:
+        if len(result_json) > settings.DATASET_TOKEN_TRUNCATION_LIMIT:
             return True, f"Query result is too large: {len(result_json)}"
 
         # Check number of columns in first record
-        if result and isinstance(result[0], dict) and len(result[0]) > 50:
+        if (
+            result
+            and isinstance(result[0], dict)
+            and len(result[0]) > settings.COLUMN_TRUNCATION_LIMIT
+        ):
             return (
                 True,
                 f"Query returned too many columns: {len(result[0])}",
@@ -50,10 +55,10 @@ def truncate_result_for_llm(result: list[dict] | None) -> list[dict] | None:
         The truncated result list with an appended note if truncation occurred,
         or the original result if no truncation was needed.
     """
-    if not result or len(result) <= 10:
+    if not result or len(result) <= settings.DISPLAY_ROWS_AFTER_TRUNCATION_LIMIT:
         return result
 
-    truncated = result[:10]
+    truncated = result[: settings.DISPLAY_ROWS_AFTER_TRUNCATION_LIMIT]
 
     if isinstance(truncated[0], dict):
         truncated.append(

--- a/chat-server/app/utils/model_registry/model_provider.py
+++ b/chat-server/app/utils/model_registry/model_provider.py
@@ -175,7 +175,7 @@ def get_configured_llm_for_node(
     elif json_mode:
         llm = llm.bind(response_format={"type": "json_object"})
     if force_tool_calls:
-        llm = llm.bind(tool_choice=True)
+        llm = llm.bind(tool_choice="required")
     return llm  # type: ignore
 
 

--- a/chat-server/app/utils/providers/llm_providers/custom.py
+++ b/chat-server/app/utils/providers/llm_providers/custom.py
@@ -1,11 +1,40 @@
 from langchain_openai import ChatOpenAI
 
 from app.core.config import settings
+from app.core.log import custom_logger as logger
 
 from .base import BaseLLMProvider
 
 
 class CustomLLMProvider(BaseLLMProvider):
+    # Combined mapping of provider names to their base URLs and API key settings
+    PROVIDER_CONFIG = {
+        "openai": {"base_url": "https://api.openai.com/v1", "api_key_env": "OPENAI_API_KEY"},
+        "groq": {"base_url": "https://api.groq.com/openai/v1", "api_key_env": "GROQ_API_KEY"},
+        "togetherai": {
+            "base_url": "https://api.together.xyz/v1",
+            "api_key_env": "TOGETHER_API_KEY",
+        },
+        "perplexity": {
+            "base_url": "https://api.perplexity.ai",
+            "api_key_env": "PERPLEXITY_API_KEY",
+        },
+        "fireworks": {
+            "base_url": "https://api.fireworks.ai/inference/v1",
+            "api_key_env": "FIREWORKS_API_KEY",
+        },
+        "anthropic": {
+            "base_url": "https://api.anthropic.com/v1/",
+            "api_key_env": "ANTHROPIC_API_KEY",
+        },
+        "deepinfra": {
+            "base_url": "https://api.deepinfra.com/v1/openai",
+            "api_key_env": "DEEPINFRA_API_TOKEN",
+        },
+        "huggingface": {"base_url": "https://router.huggingface.co/v1", "api_key_env": "HF_TOKEN"},
+        "other": {"base_url": settings.CUSTOM_LLM_BASE_URL, "api_key_env": "CUSTOM_LLM_API_KEY"},
+    }
+
     def __init__(self, metadata: dict[str, str]):
         self.metadata = metadata
 
@@ -13,9 +42,11 @@ class CustomLLMProvider(BaseLLMProvider):
         self,
         model_name: str,
     ):
+        # Get provider configuration (base URL and API key)
+        base_url, api_key = self._get_provider_config()
         kwargs = {
-            "api_key": settings.CUSTOM_LLM_API_KEY,
-            "base_url": settings.CUSTOM_LLM_BASE_URL,
+            "api_key": api_key,
+            "base_url": base_url,
             "model": model_name,
             "metadata": {
                 **self.metadata,
@@ -25,3 +56,30 @@ class CustomLLMProvider(BaseLLMProvider):
         llm = ChatOpenAI(**kwargs)
 
         return llm
+
+    def _get_provider_config(self) -> tuple[str, str]:
+        """
+        Get the appropriate base URL and API key based on the CUSTOM_LLM_GATEWAY_PROVIDER setting.
+        Falls back to CUSTOM_LLM_BASE_URL and CUSTOM_LLM_API_KEY if provider is not recognized or not set.
+
+        Returns:
+            tuple[str, str]: (base_url, api_key)
+
+        Raises:
+            ValueError: If provider is specified but API key is not set
+        """
+        provider = settings.CUSTOM_PROVIDER_NAME.lower().strip()
+        config = self.PROVIDER_CONFIG.get(provider, self.PROVIDER_CONFIG["other"])
+        base_url = config["base_url"]
+        api_key_env = config["api_key_env"]
+
+        provider_api_key = getattr(settings, api_key_env, "")
+
+        if not provider_api_key:
+            raise ValueError(
+                f"Provider '{provider}' is configured but the required API key '{api_key_env}' is not set. "
+                f"Please set the {api_key_env} environment variable."
+            )
+        # Log which provider and base URL are being used
+        logger.info(f"Using provider '{provider}' with base URL: {base_url}")
+        return base_url, provider_api_key

--- a/chat-server/app/utils/providers/llm_providers/openrouter.py
+++ b/chat-server/app/utils/providers/llm_providers/openrouter.py
@@ -21,7 +21,7 @@ class OpenRouterLLMProvider(BaseLLMProvider):
                 **self.metadata,
             },
             "extra_body": {
-                "models": [settings.FALLBACK_MODEL],
+                "models": [settings.DEFAULT_LLM_MODEL],
             },
         }
 

--- a/chat-server/app/workflow/graph/visualize_data_graph/utils.py
+++ b/chat-server/app/workflow/graph/visualize_data_graph/utils.py
@@ -17,6 +17,13 @@ from app.core.session import SingletonAiohttp
 
 from .types import Dataset, PreviousVisualizationJsonType
 
+access_key_id = settings.S3_ACCESS_KEY
+secret_access_key = settings.S3_SECRET_KEY
+region = settings.S3_REGION
+bucket_name = settings.S3_BUCKET
+internal_s3_host = settings.INTERNAL_S3_HOST
+external_s3_host = settings.EXTERNAL_S3_HOST
+
 
 def list_to_csv(list_dict: list[list]) -> str:
     output = StringIO()
@@ -46,6 +53,7 @@ async def get_python_code_files(viz_paths: list[PreviousVisualizationJsonType]):
 
 @traceable(run_type="chain", name="get_python_code_for_viz")
 async def get_python_code_from_viz(viz_path: str):
+    viz_path = viz_path.replace(external_s3_host, internal_s3_host)
     viz_path = viz_path.rsplit("-", 1)[0].strip()
     python_code_path = viz_path + ".py"
     client = SingletonAiohttp.get_aiohttp_client()
@@ -191,12 +199,6 @@ async def upload_visualization_result_data(data: list[str], python_code: str) ->
         list[str]: URLs of the uploaded files in S3 storage.
     """
 
-    access_key_id = settings.S3_ACCESS_KEY
-    secret_access_key = settings.S3_SECRET_KEY
-    region = settings.S3_REGION
-    bucket_name = settings.S3_BUCKET
-    s3_host = settings.S3_HOST
-
     if not all([access_key_id, secret_access_key, bucket_name]):
         raise ValueError("S3 credentials or bucket name not set in environment variables")
 
@@ -204,7 +206,7 @@ async def upload_visualization_result_data(data: list[str], python_code: str) ->
     s3_paths = []
     async with session.client(  # type: ignore
         "s3",
-        endpoint_url=s3_host,
+        endpoint_url=internal_s3_host,
         region_name=region,
         aws_access_key_id=access_key_id,
         aws_secret_access_key=secret_access_key,
@@ -222,7 +224,7 @@ async def upload_visualization_result_data(data: list[str], python_code: str) ->
             )
 
             upload_tasks.append(json_task)
-            s3_path = f"{s3_host}/{bucket_name}/{json_file_key}"
+            s3_path = f"{external_s3_host}/{bucket_name}/{json_file_key}"
             s3_paths.append(s3_path)
         py_file_key = f"visualizations/{timestamp}-{unique_id}.py"
         py_task = s3_client.put_object(

--- a/chat-server/tests/unit/test_health.py
+++ b/chat-server/tests/unit/test_health.py
@@ -38,18 +38,31 @@ class TestHealthEndpoints:
         """
         Test that the health check endpoint returns a successful response with correct structure.
         """
-        response = client.get("/api/v1/health")
+        # Mock all health check functions to return healthy status
+        with (
+            patch("app.api.v1.routers.health.check_qdrant_health") as mock_qdrant,
+            patch("app.api.v1.routers.health.check_llm_provider_health") as mock_llm,
+            patch("app.api.v1.routers.health.check_gopie_server_health") as mock_gopie,
+            patch("app.api.v1.routers.health.check_embedding_provider_health") as mock_embedding,
+        ):
+            # Configure all health checks to return healthy status
+            mock_qdrant.return_value = {"status": "healthy", "collections_count": 1}
+            mock_llm.return_value = {"status": "healthy", "provider_type": "test"}
+            mock_gopie.return_value = {"status": "healthy", "server_reachable": True}
+            mock_embedding.return_value = {"status": "healthy", "provider_type": "test"}
 
-        assert response.status_code == 200
+            response = client.get("/api/v1/health")
 
-        data = response.json()
-        assert "status" in data
-        assert "timestamp" in data
-        assert "service" in data
+            assert response.status_code == 200
 
-        assert data["status"] == "healthy"
-        assert data["service"] == "gopie-chat-server"
+            data = response.json()
+            assert "status" in data
+            assert "timestamp" in data
+            assert "service" in data
 
-        # Verify timestamp is a valid ISO format
-        timestamp = data["timestamp"]
-        datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            assert data["status"] == "healthy"
+            assert data["service"] == "gopie-chat-server"
+
+            # Verify timestamp is a valid ISO format
+            timestamp = data["timestamp"]
+            datetime.fromisoformat(timestamp.replace("Z", "+00:00"))

--- a/chat-server/tests/unit/test_llm_providers.py
+++ b/chat-server/tests/unit/test_llm_providers.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 
+import pytest
 from portkey_ai import PORTKEY_GATEWAY_URL
 
 from app.utils.providers.llm_providers.cloudflare import CloudflareLLMProvider
@@ -224,6 +225,7 @@ class TestOpenRouterLLMProvider:
                 base_url="https://openrouter.ai/api/v1",
                 model="gpt-4",
                 metadata=sample_metadata,
+                extra_body={"models": [mock_settings.DEFAULT_LLM_MODEL]},
             )
             assert result == mock_model
 
@@ -285,22 +287,32 @@ class TestCustomLLMProvider:
 
         assert provider.metadata == sample_metadata
 
-    def test_get_llm_model(self, sample_metadata):
+    def test_get_llm_model_with_custom_provider(self, sample_metadata):
         """
-        Test that CustomLLMProvider.get_llm_model initializes and returns a ChatOpenAI model with the correct parameters using provided metadata.
+        Test that CustomLLMProvider.get_llm_model works with custom/other provider configuration.
         """
         with (
             patch("app.utils.providers.llm_providers.custom.settings") as mock_settings,
             patch("app.utils.providers.llm_providers.custom.ChatOpenAI") as mock_chat_openai,
         ):
 
+            # Set up settings to mock the PROVIDER_CONFIG for "other"
+            mock_settings.CUSTOM_PROVIDER_NAME = "other"
             mock_settings.CUSTOM_LLM_API_KEY = "custom_key"
             mock_settings.CUSTOM_LLM_BASE_URL = "https://custom.api"
+
+            # Mock the provider config dict access
+            provider_config = {
+                "other": {"base_url": "https://custom.api", "api_key_env": "CUSTOM_LLM_API_KEY"}
+            }
+
             mock_model = Mock()
             mock_chat_openai.return_value = mock_model
 
             provider = CustomLLMProvider(sample_metadata)
-            result = provider.get_llm_model("gpt-4")
+            # Patch the PROVIDER_CONFIG to use our mocked values
+            with patch.object(provider, "PROVIDER_CONFIG", provider_config):
+                result = provider.get_llm_model("gpt-4")
 
             mock_chat_openai.assert_called_once_with(
                 api_key="custom_key",
@@ -313,3 +325,189 @@ class TestCustomLLMProvider:
                 },
             )
             assert result == mock_model
+
+    def test_get_llm_model_with_openai_provider(self, sample_metadata):
+        """
+        Test that CustomLLMProvider correctly configures OpenAI provider.
+        """
+        with (
+            patch("app.utils.providers.llm_providers.custom.settings") as mock_settings,
+            patch("app.utils.providers.llm_providers.custom.ChatOpenAI") as mock_chat_openai,
+        ):
+
+            mock_settings.CUSTOM_PROVIDER_NAME = "openai"
+            mock_settings.OPENAI_API_KEY = "openai_key_123"
+            mock_model = Mock()
+            mock_chat_openai.return_value = mock_model
+
+            provider = CustomLLMProvider(sample_metadata)
+            result = provider.get_llm_model("gpt-4")
+
+            mock_chat_openai.assert_called_once_with(
+                api_key="openai_key_123",
+                base_url="https://api.openai.com/v1",
+                model="gpt-4",
+                metadata={
+                    "user": "test_user",
+                    "trace_id": "test_trace_123",
+                    "chat_id": "test_chat_456",
+                },
+            )
+            assert result == mock_model
+
+    def test_get_llm_model_with_groq_provider(self, sample_metadata):
+        """
+        Test that CustomLLMProvider correctly configures Groq provider.
+        """
+        with (
+            patch("app.utils.providers.llm_providers.custom.settings") as mock_settings,
+            patch("app.utils.providers.llm_providers.custom.ChatOpenAI") as mock_chat_openai,
+        ):
+
+            mock_settings.CUSTOM_PROVIDER_NAME = "groq"
+            mock_settings.GROQ_API_KEY = "groq_key_123"
+            mock_model = Mock()
+            mock_chat_openai.return_value = mock_model
+
+            provider = CustomLLMProvider(sample_metadata)
+            result = provider.get_llm_model("llama-70b")
+
+            mock_chat_openai.assert_called_once_with(
+                api_key="groq_key_123",
+                base_url="https://api.groq.com/openai/v1",
+                model="llama-70b",
+                metadata={
+                    "user": "test_user",
+                    "trace_id": "test_trace_123",
+                    "chat_id": "test_chat_456",
+                },
+            )
+            assert result == mock_model
+
+    def test_get_llm_model_with_anthropic_provider(self, sample_metadata):
+        """
+        Test that CustomLLMProvider correctly configures Anthropic provider.
+        """
+        with (
+            patch("app.utils.providers.llm_providers.custom.settings") as mock_settings,
+            patch("app.utils.providers.llm_providers.custom.ChatOpenAI") as mock_chat_openai,
+        ):
+
+            mock_settings.CUSTOM_PROVIDER_NAME = "anthropic"
+            mock_settings.ANTHROPIC_API_KEY = "anthropic_key_123"
+            mock_model = Mock()
+            mock_chat_openai.return_value = mock_model
+
+            provider = CustomLLMProvider(sample_metadata)
+            result = provider.get_llm_model("claude-3-sonnet")
+
+            mock_chat_openai.assert_called_once_with(
+                api_key="anthropic_key_123",
+                base_url="https://api.anthropic.com/v1/",
+                model="claude-3-sonnet",
+                metadata={
+                    "user": "test_user",
+                    "trace_id": "test_trace_123",
+                    "chat_id": "test_chat_456",
+                },
+            )
+            assert result == mock_model
+
+    def test_get_provider_config_missing_api_key_raises_error(self, sample_metadata):
+        """
+        Test that CustomLLMProvider raises ValueError when API key is missing for a provider.
+        """
+        with (patch("app.utils.providers.llm_providers.custom.settings") as mock_settings,):
+            mock_settings.CUSTOM_PROVIDER_NAME = "openai"
+            mock_settings.OPENAI_API_KEY = ""  # Empty API key
+
+            provider = CustomLLMProvider(sample_metadata)
+
+            with pytest.raises(
+                ValueError,
+                match="Provider 'openai' is configured but the required API key 'OPENAI_API_KEY' is not set",
+            ):
+                provider.get_llm_model("gpt-4")
+
+    def test_get_provider_config_fallback_to_custom_provider(self, sample_metadata):
+        """
+        Test that CustomLLMProvider falls back to custom provider config for unknown providers.
+        """
+        with (
+            patch("app.utils.providers.llm_providers.custom.settings") as mock_settings,
+            patch("app.utils.providers.llm_providers.custom.ChatOpenAI") as mock_chat_openai,
+        ):
+
+            mock_settings.CUSTOM_PROVIDER_NAME = "unknown_provider"
+            mock_settings.CUSTOM_LLM_API_KEY = "fallback_key"
+            mock_settings.CUSTOM_LLM_BASE_URL = "https://fallback.api"
+
+            # Mock the provider config dict to include our fallback
+            provider_config = {
+                "other": {"base_url": "https://fallback.api", "api_key_env": "CUSTOM_LLM_API_KEY"}
+            }
+
+            mock_model = Mock()
+            mock_chat_openai.return_value = mock_model
+
+            provider = CustomLLMProvider(sample_metadata)
+            # Patch the PROVIDER_CONFIG to use our mocked values
+            with patch.object(provider, "PROVIDER_CONFIG", provider_config):
+                result = provider.get_llm_model("some-model")
+
+            mock_chat_openai.assert_called_once_with(
+                api_key="fallback_key",
+                base_url="https://fallback.api",
+                model="some-model",
+                metadata={
+                    "user": "test_user",
+                    "trace_id": "test_trace_123",
+                    "chat_id": "test_chat_456",
+                },
+            )
+            assert result == mock_model
+
+    def test_provider_config_with_all_supported_providers(self, sample_metadata):
+        """
+        Test that all supported providers in PROVIDER_CONFIG have correct configurations.
+        """
+        expected_configs = {
+            "openai": {"base_url": "https://api.openai.com/v1", "api_key_env": "OPENAI_API_KEY"},
+            "groq": {"base_url": "https://api.groq.com/openai/v1", "api_key_env": "GROQ_API_KEY"},
+            "togetherai": {
+                "base_url": "https://api.together.xyz/v1",
+                "api_key_env": "TOGETHER_API_KEY",
+            },
+            "perplexity": {
+                "base_url": "https://api.perplexity.ai",
+                "api_key_env": "PERPLEXITY_API_KEY",
+            },
+            "fireworks": {
+                "base_url": "https://api.fireworks.ai/inference/v1",
+                "api_key_env": "FIREWORKS_API_KEY",
+            },
+            "anthropic": {
+                "base_url": "https://api.anthropic.com/v1/",
+                "api_key_env": "ANTHROPIC_API_KEY",
+            },
+            "deepinfra": {
+                "base_url": "https://api.deepinfra.com/v1/openai",
+                "api_key_env": "DEEPINFRA_API_TOKEN",
+            },
+            "huggingface": {
+                "base_url": "https://router.huggingface.co/v1",
+                "api_key_env": "HF_TOKEN",
+            },
+        }
+
+        provider = CustomLLMProvider(sample_metadata)
+
+        for provider_name, expected_config in expected_configs.items():
+            config = provider.PROVIDER_CONFIG.get(provider_name)
+            assert config is not None, f"Provider {provider_name} not found in PROVIDER_CONFIG"
+            assert (
+                config["base_url"] == expected_config["base_url"]
+            ), f"Base URL mismatch for {provider_name}"
+            assert (
+                config["api_key_env"] == expected_config["api_key_env"]
+            ), f"API key env mismatch for {provider_name}"

--- a/config-noauth.env.example
+++ b/config-noauth.env.example
@@ -56,10 +56,10 @@ GOPIE_API_URL="http://gopie-server:8000"
 # ==================================
 # Chat Server General Configuration
 # ==================================
-PROJECT_NAME="Gopie Chat Server"
-API_V1_STR="/api/v1"
-MODE="development"
-GOPIE_API_ENDPOINT="http://gopie-server:8001"
+CHAT_PROJECT_NAME="Gopie Chat Server"
+CHAT_API_V1_STR="/api/v1"
+CHAT_MODE="development"
+CHAT_GOPIE_API_ENDPOINT="http://gopie-server:8001"
 
 # ==================================
 # AI Gateways & Providers (Enable one)
@@ -71,27 +71,40 @@ GOPIE_API_ENDPOINT="http://gopie-server:8001"
 # - "openrouter"  : OpenRouter for accessing multiple AI models
 # - "custom"      : Custom LLM endpoints for self-hosted models or direct provider access
 #
-# Note: For direct access to any OpenAI-compatible provider, use "custom" with:
-#   LLM_GATEWAY_PROVIDER="custom"
-#   CUSTOM_LLM_BASE_URL="<PROVIDER_BASE_URL>"
-#   CUSTOM_LLM_API_KEY="<YOUR_API_KEY>"
-#
-# Examples for popular OpenAI-compatible providers:
-#   OpenAI:  CUSTOM_LLM_BASE_URL="https://api.openai.com/v1"
-#   Gemini:  CUSTOM_LLM_BASE_URL="https://generativelanguage.googleapis.com/v1beta/openai"
-#   Groq:    CUSTOM_LLM_BASE_URL="https://api.groq.com/openai/v1"
-LLM_GATEWAY_PROVIDER="custom"
+# Note: For direct access to any OpenAI-compatible provider, use "custom" # # # with:
+#   CHAT_LLM_GATEWAY_PROVIDER="custom"
+#   CHAT_CUSTOM_PROVIDER_NAME="<PROVIDER_NAME>"
+#   CHAT_CUSTOM_LLM_BASE_URL="<PROVIDER_BASE_URL>"
+#   CHAT_CUSTOM_LLM_API_KEY="<YOUR_API_KEY>"
 
-# If Custom LLM Provider is chosen above the following two need to be updated based on the provider
-CUSTOM_LLM_BASE_URL="https://api.openai.com/v1"
-CUSTOM_LLM_API_KEY="<API KEY>"
+CHAT_LLM_GATEWAY_PROVIDER="custom"
+
+# If Custom LLM Provider is chosen above the following need to be updated based on the provider
+# The following providers are supported directly:
+# - OpenAI
+# - Gemini
+# - Groq
+# - Together
+# - Perplexity
+# - Fireworks
+# - Anthropic
+# - DeepInfra
+# - HuggingFace
+# Example Usage for OpenAI:
+#   CHAT_LLM_GATEWAY_PROVIDER="custom"
+#   CHAT_CUSTOM_PROVIDER_NAME="openai"
+#   OPENAI_API_KEY="<YOUR_API_KEY>"
+
+CHAT_CUSTOM_PROVIDER_NAME="openai" 
+CHAT_CUSTOM_LLM_BASE_URL=""
+CHAT_CUSTOM_LLM_API_KEY="<API KEY>"
 
 # Embedding Gateway Provider Options (choose one):
 # - "portkey"     : Portkey for embedding models
 # - "litellm"     : LiteLLM for embedding providers
 # - "openai"      : Direct OpenAI embeddings API
 # - "custom"      : Custom embedding endpoints
-EMBEDDING_GATEWAY_PROVIDER="openai"
+CHAT_EMBEDDING_GATEWAY_PROVIDER="openai"
 
 # Portkey
 PORTKEY_API_KEY=""
@@ -120,51 +133,58 @@ CLOUDFLARE_PROVIDER_API_KEY=""
 OPENROUTER_API_KEY=""
 OPENROUTER_BASE_URL="https://openrouter.ai/api/v1"
 
-# E2B (Code Interpreter)
-E2B_API_KEY=""
-E2B_TIMEOUT=120
+# E2B (Code Interpreter) - Chat server specific
+CHAT_E2B_API_KEY="<YOUR_E2B_API_KEY>"
+CHAT_E2B_TIMEOUT=120
 
 # If Custom Embedding Provider you need to update the following accordingly
-CUSTOM_EMBEDDING_BASE_URL=""
-CUSTOM_EMBEDDING_API_KEY=""
-CUSTOM_EMBEDDING_MODEL=""
+CHAT_CUSTOM_EMBEDDING_BASE_URL=""
+CHAT_CUSTOM_EMBEDDING_API_KEY=""
 
 # Direct Provider Keys
-OPENAI_API_KEY=""
+OPENAI_API_KEY="<YOUR_API_KEY>"
+GROQ_API_KEY="<YOUR_API_KEY>"
+TOGETHER_API_KEY="<YOUR_API_KEY>"
+PERPLEXITY_API_KEY="<YOUR_API_KEY>"
+FIREWORKS_API_KEY="<YOUR_API_KEY>"
+ANTHROPIC_API_KEY="<YOUR_API_KEY>"
+DEEPINFRA_API_TOKEN="<YOUR_API_KEY>"
+HF_TOKEN="<YOUR_API_KEY>"
 
 # ==================================
 # Default Model Configuration
 # ==================================
-FAST_MODEL="openai/gpt-4o"
-BALANCED_MODEL="google/gemini-2.5-flash"
-ADVANCED_MODEL="openai/o4-mini"
-DEFAULT_EMBEDDING_MODEL="text-embedding-3-large"
-DEFAULT_LLM_MODEL="openai/gpt-4o"
+CHAT_FAST_MODEL="gpt-4.1-mini"
+CHAT_BALANCED_MODEL="gpt-4.1"
+CHAT_ADVANCED_MODEL="gpt-5"
+CHAT_DEFAULT_LLM_MODEL="gpt-4.1"
+
+CHAT_DEFAULT_EMBEDDING_MODEL="text-embedding-3-large"
 
 
 # ==================================
 # S3 Storage (Chat Server)
 # ==================================
-S3_HOST="http://minio:9000"
-S3_ACCESS_KEY="minioadmin"
-S3_SECRET_KEY="minioadmin"
-S3_BUCKET="gopie"
-S3_SECURE="false"
-S3_REGION="us-east-1"
+CHAT_INTERNAL_S3_HOST="http://minio:9000"
+CHAT_EXTERNAL_S3_HOST="http://localhost:9000"
+CHAT_S3_ACCESS_KEY="minioadmin"
+CHAT_S3_SECRET_KEY="minioadmin"
+CHAT_S3_BUCKET="gopie"
+CHAT_S3_REGION="us-east-1"
 
 # ==================================
 # Vector Database (Qdrant)
 # ==================================
-QDRANT_HOST="qdrant"
-QDRANT_COLLECTION="dataset_collection"
-QDRANT_PORT=6333
-QDRANT_TOP_K=5
+CHAT_QDRANT_HOST="qdrant"
+CHAT_QDRANT_COLLECTION="dataset_collection"
+CHAT_QDRANT_PORT=6333
+CHAT_QDRANT_TOP_K=5
 
 # ==================================
 # LangSmith (LLM Tracing)
 # ==================================
 LANGSMITH_TRACING=false
 LANGSMITH_ENDPOINT="https://api.smith.langchain.com"
-LANGSMITH_API_KEY=""
 LANGSMITH_PROJECT="gopie-chat-server-local"
-LANGSMITH_PROMPT=false
+LANGSMITH_API_KEY=""
+CHAT_LANGSMITH_PROMPT=false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Centralized multi-provider LLM configuration with additional provider API keys and defaults.
  - Configurable result truncation limits and default embedding size.
  - Support for internal/external S3 hosts to improve visualization uploads.

- Improvements
  - Standardized CHAT_ environment variable prefix and settings loading.
  - Tuned Qdrant collection/index configuration for performance.
  - Updated OpenRouter defaults (base URL, default model).
  - More reliable tool-calling behavior.

- Bug Fixes
  - Safer SQL execution path in schema generation.

- Tests
  - Expanded provider coverage and stabilized health endpoint tests.

- Documentation
  - Updated example environment file to new CHAT_ keys and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->