### PR TITLE
fix: request header is too large

### DIFF
--- a/server/domain/models/utils.go
+++ b/server/domain/models/utils.go
@@ -1,5 +1,13 @@
 package models
 
+type RestRequest struct {
+	Columns []string          `json:"columns,omitempty"`
+	Sort    string            `json:"sort,omitempty"`
+	Limit   int               `json:"limit,omitempty"`
+	Page    int               `json:"page,omitempty"`
+	Filter  map[string]string `json:"filter,omitempty"`
+}
+
 type RestParams struct {
 	Filter       map[string]string
 	Sort         string

--- a/server/interfaces/http/routes/api/rest.go
+++ b/server/interfaces/http/routes/api/rest.go
@@ -11,35 +11,47 @@ import (
 )
 
 // @Summary Query dataset using REST API
-// @Description Query a dataset using REST-style parameters
+// @Description Query a dataset using REST-style parameters via POST body
 // @Tags query
 // @Accept json
 // @Produce json
 // @Param tableName path string true "Name of the dataset/table" example:"sales_data"
-// @Param columns query string false "Comma-separated list of columns to return" example:"id,name,value"
-// @Param sort query string false "Sort order (column name with optional -prefix for desc)" example:"-created_at"
-// @Param limit query integer false "Number of records to return" example:"10"
-// @Param page query integer false "Page number" example:"1"
+// @Param body body models.RestRequest true "Query parameters"
 // @Success 200 {array} map[string]interface{} "Query results"
 // @Failure 400 {object} responses.ErrorResponse "Invalid query parameters"
 // @Failure 500 {object} responses.ErrorResponse "Internal server error"
-// @Router /v1/api/tables/{tableName} [get]
+// @Router /v1/api/tables/{tableName} [post]
 func (h *httpHandler) rest(ctx *fiber.Ctx) error {
 	table := ctx.Params("tableName")
 	imposeLimits := ctx.Locals(middleware.ImposeLimitsCtxKey).(bool)
 
-	columns := strings.Split(ctx.Query("columns", "*"), ",")
-	filters := ctx.Queries()
-	sort := ctx.Query("sort", "")
-	limit := ctx.QueryInt("limit")
-	page := ctx.QueryInt("page", 1)
+	var req models.RestRequest
+	if len(ctx.Body()) > 0 {
+		if err := ctx.BodyParser(&req); err != nil {
+			return ctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error":   err.Error(),
+				"message": "Invalid request body",
+				"code":    fiber.StatusBadRequest,
+			})
+		}
+	}
+
+	columns := req.Columns
+	if len(columns) == 0 {
+		columns = []string{"*"}
+	}
+
+	page := req.Page
+	if page == 0 {
+		page = 1
+	}
 
 	params := models.RestParams{
 		Cols:         columns,
-		Sort:         sort,
-		Limit:        limit,
+		Sort:         req.Sort,
+		Limit:        req.Limit,
 		Page:         page,
-		Filter:       filters,
+		Filter:       req.Filter,
 		Table:        table,
 		ImposeLimits: imposeLimits,
 	}

--- a/server/interfaces/http/routes/api/routes.go
+++ b/server/interfaces/http/routes/api/routes.go
@@ -25,7 +25,7 @@ func Routes(router fiber.Router, driverSvc *services.OlapService, aiSvc *service
 	httpHandler := httpHandler{driverSvc, datasetsSvc, projectSvc, aiSvc, logger, nil}
 	// /sql endpoint with middleware to authorize datasets from sql query
 	router.Post("/sql", middleware.AuthorizeDatasetsAccessFromSql(driverSvc, projectSvc, logger), httpHandler.sql)
-	router.Get("/tables/:tableName", httpHandler.rest)
+	router.Post("/tables/:tableName", httpHandler.rest)
 	router.Post("/nl2sql", httpHandler.nl2sql)
 	router.Get("/schemas/:tableName", httpHandler.schemas)
 	router.Get("/summary/:tableName", httpHandler.summary)
@@ -39,7 +39,7 @@ func Routes(router fiber.Router, driverSvc *services.OlapService, aiSvc *service
 func InternalRoutes(router fiber.Router, driverSvc *services.OlapService, aiSvc *services.AiDriver, datasetsSvc *services.DatasetService, projectSvc *services.ProjectService, logger *logger.Logger) {
 	httpHandler := httpHandler{driverSvc, datasetsSvc, projectSvc, aiSvc, logger, nil}
 	router.Post("/sql", httpHandler.sql)
-	router.Get("/tables/:tableName", httpHandler.rest)
+	router.Post("/tables/:tableName", httpHandler.rest)
 	router.Post("/nl2sql", httpHandler.nl2sql)
 	router.Get("/schemas/:tableName", httpHandler.schemas)
 	router.Get("/summary/:tableName", httpHandler.summary)

--- a/web/src/app/projects/[projectId]/datasets/[datasetId]/api/page.tsx
+++ b/web/src/app/projects/[projectId]/datasets/[datasetId]/api/page.tsx
@@ -87,20 +87,24 @@ export default function RestApiPage({
     },
   });
 
-  const apiUrl =
-    `${process.env.NEXT_PUBLIC_GOPIE_API_URL}/v1/api/tables/${tableName}?` +
-    new URLSearchParams({
-      page,
-      limit,
-      ...(selectedColumns.length > 0 && { columns: selectedColumns.join(",") }),
-      ...(filters.length > 0 &&
-        Object.fromEntries(
+  const apiUrl = `${process.env.NEXT_PUBLIC_GOPIE_API_URL}/v1/api/tables/${tableName}`;
+  const requestBody = JSON.stringify(
+    {
+      page: parseInt(page),
+      limit: parseInt(limit),
+      ...(selectedColumns.length > 0 && { columns: selectedColumns }),
+      ...(filters.length > 0 && {
+        filter: Object.fromEntries(
           filters.map((f) => [
             `filter[${f.column}]${f.operator === "e" ? "" : f.operator}`,
             f.value,
           ])
-        )),
-    }).toString();
+        ),
+      }),
+    },
+    null,
+    2
+  );
 
   const copyToClipboard = (type: string) => {
     let textToCopy = apiUrl;
@@ -110,21 +114,29 @@ export default function RestApiPage({
         textToCopy = apiUrl;
         break;
       case "curl-cmd":
-        textToCopy = `curl -X GET "${apiUrl}"`;
+        textToCopy = `curl -X POST "${apiUrl}" -H "Content-Type: application/json" -d "${requestBody.replace(/"/g, '\\"')}"`;
         break;
       case "curl-bash":
-        textToCopy = `curl -X GET '${apiUrl}'`;
+        textToCopy = `curl -X POST '${apiUrl}' \\\n  -H 'Content-Type: application/json' \\\n  -d '${requestBody}'`;
         break;
       case "powershell":
-        textToCopy = `Invoke-WebRequest -Uri "${apiUrl}" -Method GET`;
+        textToCopy = `Invoke-WebRequest -Uri "${apiUrl}" -Method POST -ContentType "application/json" -Body '${requestBody}'`;
         break;
       case "fetch":
-        textToCopy = `fetch("${apiUrl}")
+        textToCopy = `fetch("${apiUrl}", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(${requestBody})
+})
   .then(response => response.json())
   .then(data => console.log(data));`;
         break;
       case "fetch-node":
-        textToCopy = `fetch("${apiUrl}")
+        textToCopy = `fetch("${apiUrl}", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(${requestBody})
+})
   .then(response => response.json())
   .then(data => console.log(data))
   .catch(error => console.error('Error:', error));`;
@@ -354,7 +366,13 @@ export default function RestApiPage({
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
-            <code className="text-xs mt-2 block break-all">{apiUrl}</code>
+            <code className="text-xs mt-2 block break-all">
+              <span className="text-emerald-600 font-semibold">POST</span>{" "}
+              {apiUrl}
+            </code>
+            <pre className="text-xs mt-2 bg-background/50 p-2 rounded overflow-auto max-h-32">
+              {requestBody}
+            </pre>
           </div>
           <div className="bg-zinc-950">
             {tableDataLoading ? (

--- a/web/src/lib/queries/dataset/get-table.ts
+++ b/web/src/lib/queries/dataset/get-table.ts
@@ -25,15 +25,15 @@ export const useGetTable = createQuery({
       operator: "e" | "gt" | "lt";
     }[];
   }) => {
-    const res = await apiClient.get(`v1/api/tables/${datasetId}`, {
-      searchParams: {
+    const res = await apiClient.post(`v1/api/tables/${datasetId}`, {
+      json: {
         page,
         limit,
-        columns: columns.join(","),
+        columns,
         sort: sort
           .map((s) => `${s.direction === "desc" ? "-" : ""}${s.column}`)
           .join(","),
-        ...Object.fromEntries(
+        filter: Object.fromEntries(
           filter.map((f) => [
             `filter[${f.column}]${f.operator === "e" ? "" : f.operator}`,
             f.value,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Updates**
  * Changed table data retrieval endpoint from GET to POST, with query parameters (columns, sort, limit, page, filter) now sent via JSON request body.
  * Updated web interface code snippet generation to reflect POST requests with JSON payloads for curl, PowerShell, and fetch examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->